### PR TITLE
Allow username to be a secret

### DIFF
--- a/ftp/config.json
+++ b/ftp/config.json
@@ -73,7 +73,7 @@
     "max_clients": "int",
     "users": [
       {
-        "username": "str",
+        "username": "match(^!secret [a-zA-Z0-9_\-]+$|^[a-zA-Z0-9\\d](?:[a-zA-Z0-9\\d]|-(?=[a-zA-Z0-9\\d])){0,32}$)",
         "password": "str",
         "allow_chmod": "bool",
         "allow_download": "bool",

--- a/ftp/config.json
+++ b/ftp/config.json
@@ -73,7 +73,7 @@
     "max_clients": "int",
     "users": [
       {
-        "username": "match(^[a-zA-Z0-9\\d](?:[a-zA-Z0-9\\d]|-(?=[a-zA-Z0-9\\d])){0,32}$)",
+        "username": "str",
         "password": "str",
         "allow_chmod": "bool",
         "allow_download": "bool",


### PR DESCRIPTION
# Proposed Changes
Change config.json to allow users to use a secret.
The documentation states it's allowed but actually not because of regex matching.
This PR expands the existing regex validation to allow '!secret ' followed by only a single word as well.

## Related Issues
The regex would not match a secret.
Closes https://github.com/hassio-addons/addon-ftp/issues/4!