### PR TITLE
Allow container to be stopped / restarted

### DIFF
--- a/ftp/rootfs/etc/cont-init.d/users.sh
+++ b/ftp/rootfs/etc/cont-init.d/users.sh
@@ -14,7 +14,7 @@ for user in $(bashio::config 'users|keys'); do
 
     for dir in "addons" "backup" "config" "media" "share" "ssl"; do
         if bashio::config.true "users[${user}].${dir}"; then
-            mkdir "/ftproot/users/${username}/${dir}"
+            mkdir -p "/ftproot/users/${username}/${dir}"
             mount --bind "/${dir}" "/ftproot/users/${username}/${dir}"
         fi
     done


### PR DESCRIPTION
In a docker based installation (not supervised), the container fails to restart due to mkdir error with "/ftproot/users/${username}/${dir}" already exists.
It can be worked around by manually deleting the container, but this can't be done with un-expected reboots.

# Proposed Changes

`users.sh`: add '-p' to mkdir

##  Notes
  - It might be useful for others if you could publish an up-to-date image on docker hub, I spent a couple of hours figuring out why the `/media` access wasn't working, docker hub version is 3.5 which doesn't handle "media" option
  - It would be nice to have an 'unknown option' warning for add-ons. With that, I would have been warned right away that my '"media": true' option wasn't handled, hence pointing me to the right direction


**Edit:**
Error in CI builds:
```
ERROR: unable to select packages:
  openssl-1.1.1k-r0:
    breaks: world[openssl=1.1.1j-r0]
```
Not related to this PR