### PR TITLE
Use rbind for mounting the folders so it will include all subfolders

### DIFF
--- a/ftp/rootfs/etc/cont-init.d/users.sh
+++ b/ftp/rootfs/etc/cont-init.d/users.sh
@@ -15,7 +15,7 @@ for user in $(bashio::config 'users|keys'); do
     for dir in "addons" "backup" "config" "media" "share" "ssl"; do
         if bashio::config.true "users[${user}].${dir}"; then
             mkdir "/ftproot/users/${username}/${dir}"
-            mount --bind "/${dir}" "/ftproot/users/${username}/${dir}"
+            mount --rbind "/${dir}" "/ftproot/users/${username}/${dir}"
         fi
     done
 


### PR DESCRIPTION

# Proposed Changes

use --rbind for mounting the folders so it will include all subfolders (I had an issue that it would not include mode than one level)