### PR TITLE
New "chroot" option 

### DIFF
--- a/ftp/DOCS.md
+++ b/ftp/DOCS.md
@@ -224,6 +224,10 @@ Allow the user to access the `/share` directory.
 
 Allow the user to access the `/ssl` directory.
 
+#### Sub-option: `chroot_to_share`
+
+Allow the user to have its root set to the `/share` directory (for instance, useful for cameras which do not permit to specify a folder to upload screenshots).
+
 ### Option: `i_like_to_be_pwned`
 
 Adding this option to the add-on configuration allows to you bypass the

--- a/ftp/DOCS.md
+++ b/ftp/DOCS.md
@@ -59,6 +59,7 @@ users:
     media: true
     share: true
     ssl: false
+    chroot: none
   - username: camera
     password: changeme
     allow_chmod: false
@@ -69,8 +70,9 @@ users:
     backup: false
     config: false
     media: false
-    share: true
+    share: false
     ssl: false
+    chroot: share
 ```
 
 **Note**: _This is just an example, don't copy and paste it! Create your own!_
@@ -224,9 +226,19 @@ Allow the user to access the `/share` directory.
 
 Allow the user to access the `/ssl` directory.
 
-#### Sub-option: `chroot_to_share`
+#### Sub-option: `chroot`
 
-Allow the user to have its root set to the `/share` directory (for instance, useful for cameras which do not permit to specify a folder to upload screenshots).
+Allow the user to have its root set to the specified directory (for instance, useful for cameras which do not permit to specify a folder to upload screenshots).
+
+Allowed values are:
+- `none`: No specific chroot for this user
+- `addons`: Chroot user to `addons`
+- `config`: Chroot user to `config`
+- `media`: Chroot user to `media`
+- `share`: Chroot user to `share`
+- `ssl`: Chroot user to `ssl`
+
+Note: when setting this option to something else than `none`, the previous options to mount directories will be ignored.
 
 ### Option: `i_like_to_be_pwned`
 

--- a/ftp/Dockerfile
+++ b/ftp/Dockerfile
@@ -22,7 +22,7 @@ RUN \
     && cd - \
     \
     && apk add --no-cache \
-        openssl=3.0.7-r0 \
+        openssl=3.0.7-r2 \
         vsftpd=3.0.5-r2 \
     \
     && apk del --no-cache --purge .build-dependencies \

--- a/ftp/config.yaml
+++ b/ftp/config.yaml
@@ -1,10 +1,10 @@
 ---
-name: HugoKs3 FTP
-version: dev-2
-slug: hugoks3-ftp
-description: My own FTP Server
-url: https://github.com/hugoKs3/addon-ftp
-codenotary: hugo@questroy.com
+name: FTP
+version: dev
+slug: ftp
+description: A secure and fast FTP server for Home Assistant
+url: https://github.com/hassio-addons/addon-ftp
+codenotary: codenotary@frenck.dev
 startup: services
 arch:
   - aarch64

--- a/ftp/config.yaml
+++ b/ftp/config.yaml
@@ -50,6 +50,7 @@ options:
       media: true
       share: true
       ssl: false
+      chroot_to_share: false
 schema:
   log_level: list(trace|debug|info|notice|warning|error|fatal)?
   port: port
@@ -78,4 +79,5 @@ schema:
       media: bool
       share: bool
       ssl: bool
+      chroot_to_share: bool
   i_like_to_be_pwned: bool?

--- a/ftp/config.yaml
+++ b/ftp/config.yaml
@@ -1,10 +1,10 @@
 ---
-name: FTP
-version: dev
-slug: ftp
-description: A secure and fast FTP server for Home Assistant
-url: https://github.com/hassio-addons/addon-ftp
-codenotary: codenotary@frenck.dev
+name: HugoKs3 FTP
+version: dev-2
+slug: hugoks3-ftp
+description: My own FTP Server
+url: https://github.com/hugoKs3/addon-ftp
+codenotary: hugo@questroy.com
 startup: services
 arch:
   - aarch64
@@ -27,7 +27,7 @@ map:
 options:
   port: 21
   data_port: 20
-  banner: Welcome to the Hass.io FTP service.
+  banner: Welcome to the HugoKs3 FTP service.
   pasv: true
   pasv_min_port: 30000
   pasv_max_port: 30010
@@ -50,7 +50,7 @@ options:
       media: true
       share: true
       ssl: false
-      chroot_to_share: false
+      chroot: none
 schema:
   log_level: list(trace|debug|info|notice|warning|error|fatal)?
   port: port
@@ -79,5 +79,5 @@ schema:
       media: bool
       share: bool
       ssl: bool
-      chroot_to_share: bool
+      chroot: list(none|addons|config|media|share|ssl)?
   i_like_to_be_pwned: bool?

--- a/ftp/config.yaml
+++ b/ftp/config.yaml
@@ -27,7 +27,7 @@ map:
 options:
   port: 21
   data_port: 20
-  banner: Welcome to the HugoKs3 FTP service.
+  banner: Welcome to the Hass.io FTP service.
   pasv: true
   pasv_min_port: 30000
   pasv_max_port: 30010

--- a/ftp/rootfs/etc/s6-overlay/s6-rc.d/init-users/run
+++ b/ftp/rootfs/etc/s6-overlay/s6-rc.d/init-users/run
@@ -13,15 +13,16 @@ for user in $(bashio::config 'users|keys'); do
     mkdir -p "/ftproot/users/${username}"
     touch "/etc/vsftpd/users/${username}"
 
-    for dir in "addons" "backup" "config" "media" "share" "ssl"; do
-        if bashio::config.true "users[${user}].${dir}"; then
-            mkdir "/ftproot/users/${username}/${dir}"
-            mount --rbind "/${dir}" "/ftproot/users/${username}/${dir}"
-        fi
-    done
-
-    if bashio::config.true "users[${user}].chroot_to_share"; then
-        mount --bind "/share" "/ftproot/users/${username}"
+    if ! bashio::config.equals "users[${user}].chroot" "none"; then
+        chroot=$(bashio::config "users[${user}].chroot")
+        mount --rbind "/${chroot}" "/ftproot/users/${username}"
+    else
+        for dir in "addons" "backup" "config" "media" "share" "ssl"; do
+            if bashio::config.true "users[${user}].${dir}"; then
+                mkdir "/ftproot/users/${username}/${dir}"
+                mount --rbind "/${dir}" "/ftproot/users/${username}/${dir}"
+            fi
+        done
     fi
 
     if bashio::config.true "users[${user}].allow_chmod"; then

--- a/ftp/rootfs/etc/s6-overlay/s6-rc.d/init-users/run
+++ b/ftp/rootfs/etc/s6-overlay/s6-rc.d/init-users/run
@@ -20,6 +20,10 @@ for user in $(bashio::config 'users|keys'); do
         fi
     done
 
+    if bashio::config.true "users[${user}].chroot_to_share"; then
+        mount --bind "/share" "/ftproot/users/${username}"
+    fi
+
     if bashio::config.true "users[${user}].allow_chmod"; then
         echo 'chmod_enable=YES' >> "/etc/vsftpd/users/${username}"
     fi


### PR DESCRIPTION
# Proposed Changes

This PR provides a new option at user level to allow setting the root of the user to the "/share" folder.
Such an option is especially useful for cameras automatic screenshot uploads which do not allow to specify a folder and only upload at the root of the user.

Note: Included in this PR is the update of OpenSSL dependency to 3.0.7-r**2**

