### PR TITLE
Install pam_pwdfile to /usr/lib/security instead of /lib/security

### DIFF
--- a/ftp/Dockerfile
+++ b/ftp/Dockerfile
@@ -18,7 +18,7 @@ RUN \
     && curl -sSL https://github.com/tiwe-de/libpam-pwdfile/archive/v1.0.tar.gz \
         | tar xz --strip 1 \
     && make \
-    && make install \
+    && PAM_LIB_DIR=/usr/lib/security make install \
     && cd - \
     \
     && apk add --no-cache \


### PR DESCRIPTION
# Proposed Changes

Install pam_pwdfile to /usr/lib/security instead of /lib/security

Alpine changed their default in https://gitlab.alpinelinux.org/alpine/aports/-/commit/390b824324986cc9f4a8cca5e13d9c09b8e88855


## Related Issues

fixes #232 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated the FTP service setup process to ensure dependencies are installed in the correct location.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->